### PR TITLE
status and report included

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,43 @@ Things to capture:
 
 
 ## GetStatus API
-
+PATH : `<baseurl>/status?tdeiRecordId=<recordId>`
 This is a single API with no authorization rules. This API is responsible for sending in the status of an uploaded file
 and the history of actions/validations that happened to it.
+
+Example response:
+
+When something fails
+```json
+{
+    "tdeiRecordId": "d2c6b3512d634d6fb315b80588ad30ff",
+    "stage": "flex-data-service failed",
+    "isComplete": true,
+    "filePath": "https://tdeisamplestorage.blob.core.windows.net/gtfsflex/2023%2FMARCH%2F5e339544-3b12-40a5-8acd-78c66d1fa981%2Fsuccess_1_all_attrs_d2c6b3512d634d6fb315b80588ad30ff.zip",
+    "status": "Error occured while processing flex requestError: Service id not found or inactive."
+}
+```
+When process is complete
+```json
+{
+    "tdeiRecordId": "70b5cff7dd7b46cd88a0d3df89f6e9d8",
+    "stage": "flex-data-service",
+    "isComplete": true,
+    "filePath": "https://tdeisamplestorage.blob.core.windows.net/gtfsflex/2023%2FMARCH%2F5e339544-3b12-40a5-8acd-78c66d1fa981%2Fsuccess_1_all_attrs_70b5cff7dd7b46cd88a0d3df89f6e9d8.zip",
+    "status": "Processing complete"
+}
+```
+When it is in progress
+```json
+{
+    "tdeiRecordId": "105402ac9ac149999dd78e463c4eb049",
+    "stage": "Flex-Validation",
+    "isComplete": false,
+    "filePath": "https://tdeisamplestorage.blob.core.windows.net/gtfsflex/2023%2FMARCH%2F5e339544-3b12-40a5-8acd-78c66d1fa981%2Fsuccess_1_all_attrs_105402ac9ac149999dd78e463c4eb049.zip",
+    "status": "Pending with data-service"
+}
+```
+
+## GetReport API
+PATH : `<baseurl>/report?tdeiRecordId=<recordId>`
+This API gives out the complete history of the record

--- a/src/controller/status-controller.ts
+++ b/src/controller/status-controller.ts
@@ -16,7 +16,8 @@ export class StatusController implements IController{
     }
 
     public intializeRoutes() {
-        this.router.get(`${this.path}`, this.getStatus);
+        this.router.get(`${this.path}`, this.getStageReport);
+        this.router.get(`/report`,this.getStatus);
     }
 
     getStatus = async (request: Request, response: express.Response) => {
@@ -43,6 +44,31 @@ export class StatusController implements IController{
         }
     } 
        
+    }
+
+    getStageReport = async (request:Request, response: express.Response) =>{
+
+        const recordId = request.query.tdeiRecordId as string;
+        console.log('Record Id');
+        console.log(recordId);
+        try {
+        if(recordId != ""){
+            var record = await this.databaseService.getStatus(recordId);
+                
+            response.send(Record.recordToReport(record));
+        }
+        else {
+             // return loaded posts
+            response.status(404).send("Record Id is empty");
+        }
+    } catch(e){
+        if(e instanceof HttpException){
+            response.status(e.status).send(e.message);
+        }
+        else {
+            response.send(e);
+        }
+    } 
     }
 
 

--- a/src/models/record.ts
+++ b/src/models/record.ts
@@ -3,6 +3,7 @@ import { Queue, QueueMessage } from "nodets-ms-core/lib/core/queue";
 import { AbstractDomainEntity, Prop } from "nodets-ms-core/lib/models";
 import { QueueMessageContent } from "./messages/queue-message-content";
 import { RecordResponse } from "./record-response";
+import { ReportResponse } from "./report-response";
 
 export default class Record extends AbstractDomainEntity {
     // constructor(public name: string, public price: number, public category: string, public id?: ObjectId) {}
@@ -76,6 +77,85 @@ export default class Record extends AbstractDomainEntity {
 
         }
         return recordResponse;
+    }
+
+    static recordToReport(record: Record): ReportResponse {
+        var recordResponse = ReportResponse.from(record);
+        if(record.history[0]){
+            const message = record.history[0];
+            const content = QueueMessageContent.from(message.data);
+            const uploadPath = content.meta.file_upload_path;
+            recordResponse.filePath = uploadPath;
+
+        }
+        if(record.status !== "true"){
+            // something failed
+            recordResponse.stage = record.stage + " failed";
+            recordResponse.isComplete = true;
+            recordResponse.status  = record.statusMessage ?? "";
+            return recordResponse;
+        }
+
+        recordResponse.isComplete = Record.isProcessingComplete(record);
+        if(recordResponse.isComplete){
+            recordResponse.status = "Processing complete";
+        }
+        else{
+            // Need to give out the correct stage.
+            recordResponse.status = "Pending with "+ Record.nextStage(record);
+        }
+         
+        return recordResponse;
+    }
+
+    static nextStage(record:Record):string {
+        var stages = ["upload","validation","data-service"];
+        record.history.forEach((message)=>{
+                
+            const content = QueueMessageContent.from(message.data);
+            const historyStage = content.stage.toLocaleLowerCase();
+            stages.forEach((singleStage)=>{
+                if(historyStage.endsWith(singleStage)){
+                    stages = stages.filter(item=>item!=singleStage);
+                }
+            })
+        });
+        if(stages.length == 0){
+        return "";
+        }
+        else {
+            return stages[0];
+        }
+    }
+
+    static isProcessingComplete(record:Record):boolean {
+        // Check for the stages
+        const stages = ["upload","validation","data-service"];
+        // get the history
+        if(record.history.length < stages.length){
+            return false;
+        }
+        else {
+            // make sure all the fields are there.
+            var count = 0;
+            record.history.forEach((message)=>{
+                
+                const content = QueueMessageContent.from(message.data);
+                console.log(content.stage);
+                const stage = content.stage.toLowerCase();
+                // Should be available for content to be procesesd.
+                stages.forEach((singleStage)=>{
+                    if(stage.endsWith(singleStage)){
+                        count++;
+                    }
+                });
+            });
+            if(count === stages.length){
+                return true;
+            }
+
+        }
+        return false;
     }
 
 }

--- a/src/models/report-response.ts
+++ b/src/models/report-response.ts
@@ -1,0 +1,20 @@
+import { AbstractDomainEntity, Prop } from "nodets-ms-core/lib/models";
+
+export class ReportResponse extends AbstractDomainEntity{
+
+    @Prop()
+    tdeiRecordId!:string;
+
+    @Prop()
+    stage!:string;
+
+    @Prop()
+    isComplete:boolean = false;
+    
+    @Prop()
+    filePath?:string;
+
+    @Prop()
+    status!:string;
+
+}


### PR DESCRIPTION
Includes the get status report
`status?tdeiRecordId=<>` API is changed to give relevant information. 
- Readme updated with the appropriate response messages for status

## Testing
 - This is tested using the following methods
 -  For invalid/failure cases, invalid payload (wrong station_id) is sent and the message captured
 - For in progress cases, data-service is paused and checked
 - For success case, a valid payload is sent and recorded.
NOTE:
This is checked for gtfs-flex only