### PR TITLE
file path removed from response

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ When something fails
     "tdeiRecordId": "d2c6b3512d634d6fb315b80588ad30ff",
     "stage": "flex-data-service failed",
     "isComplete": true,
-    "filePath": "https://tdeisamplestorage.blob.core.windows.net/gtfsflex/2023%2FMARCH%2F5e339544-3b12-40a5-8acd-78c66d1fa981%2Fsuccess_1_all_attrs_d2c6b3512d634d6fb315b80588ad30ff.zip",
     "status": "Error occured while processing flex requestError: Service id not found or inactive."
 }
 ```
@@ -40,7 +39,6 @@ When process is complete
     "tdeiRecordId": "70b5cff7dd7b46cd88a0d3df89f6e9d8",
     "stage": "flex-data-service",
     "isComplete": true,
-    "filePath": "https://tdeisamplestorage.blob.core.windows.net/gtfsflex/2023%2FMARCH%2F5e339544-3b12-40a5-8acd-78c66d1fa981%2Fsuccess_1_all_attrs_70b5cff7dd7b46cd88a0d3df89f6e9d8.zip",
     "status": "Processing complete"
 }
 ```
@@ -50,7 +48,6 @@ When it is in progress
     "tdeiRecordId": "105402ac9ac149999dd78e463c4eb049",
     "stage": "Flex-Validation",
     "isComplete": false,
-    "filePath": "https://tdeisamplestorage.blob.core.windows.net/gtfsflex/2023%2FMARCH%2F5e339544-3b12-40a5-8acd-78c66d1fa981%2Fsuccess_1_all_attrs_105402ac9ac149999dd78e463c4eb049.zip",
     "status": "Pending with data-service"
 }
 ```

--- a/src/models/record-response.ts
+++ b/src/models/record-response.ts
@@ -32,9 +32,6 @@ export class RecordResponse extends AbstractDomainEntity {
     statusMessage?:string;
 
     @Prop()
-    filePath?:string;
-
-    @Prop()
     history:QueueMessage[] = []
 
 }

--- a/src/models/record.ts
+++ b/src/models/record.ts
@@ -72,9 +72,6 @@ export default class Record extends AbstractDomainEntity {
         if(record.history[0]){
             const message = record.history[0];
             const content = QueueMessageContent.from(message.data);
-            const uploadPath = content.meta.file_upload_path;
-            recordResponse.filePath = uploadPath;
-
         }
         return recordResponse;
     }
@@ -84,9 +81,6 @@ export default class Record extends AbstractDomainEntity {
         if(record.history[0]){
             const message = record.history[0];
             const content = QueueMessageContent.from(message.data);
-            const uploadPath = content.meta.file_upload_path;
-            recordResponse.filePath = uploadPath;
-
         }
         if(record.status !== "true"){
             // something failed

--- a/src/models/report-response.ts
+++ b/src/models/report-response.ts
@@ -12,9 +12,6 @@ export class ReportResponse extends AbstractDomainEntity{
     isComplete:boolean = false;
     
     @Prop()
-    filePath?:string;
-
-    @Prop()
     status!:string;
 
 }


### PR DESCRIPTION
As per the discussion in April 3, the logger service should not respond back with the filepath
- the filepath of the uploaded record is removed
- Readme is also updated.
- The gateway will have to be updated with the newer swagger data and the response.
Reference task number : 282